### PR TITLE
Removed Keyvault from package repo ci/cd pipeline (devops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,6 @@ These library groups contain
 
 - AML workspace credentials
 - PAT for connecting from agent to artifacts feed (or use a superuser)
-- Keyvault name and keys for doc publication on DevOps Wiki
 
 In it, we need at least the following keys:
 For connecting with Azure Machine Learning:
@@ -481,18 +480,15 @@ For connecting with the DevOps artifacts feed:
 PatUsername
 DevOpsPAT
 
-For connecting with the DevOps Wiki (and getting credentials from a shared keyvault):
-SharedKeyvault
+For connecting with the DevOps Wiki:
+WikiId
+WikiSecret
 TenantName
 
 And optionally, for connecting with a keyvault (see also use_keyvault_template.yml in the project repo):
 AmlServiceConnection
 AmlKeyvaultName
 AmlPatSecretName
-
-##### 8.1.6 Keyvault
-Necessary for Service principal for wiki generation (todo: change to service connection).
-We need to have keys SP-Wiki-ID and SP-Wiki-SECRET stored in our keyvault in order to publish the docs to our DevOps Wiki.
 
 #### 8.1 Github
 Doc generation is not implemented yet.

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ All notable changes to this repo will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this repo adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0] - 2025-09-26
+Removed the WikiGenerator keyvault from DevOps CI/CD pipelines.
+
+### **Changed**
+- The keys WikiId and WikiSecret are moved from the SharedKeyvault to the AmlProdGroup.
+
 ## [0.1.1] - 2025-08-28
 Fix package repo ci/cd and remove double prompts.
 

--- a/package_repo/cookiecutter.json
+++ b/package_repo/cookiecutter.json
@@ -15,6 +15,6 @@
         "author_name": "Author name",
         "author_email": "Author email"
     },
-    "__cookiecutter_template_version": "0.1.1",
+    "__cookiecutter_template_version": "0.2.0",
     "_extensions": ["local_extensions.AdditionalPrompts"]
 }

--- a/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/main.yml
+++ b/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/main.yml
@@ -114,11 +114,10 @@ stages:
           python_version: ${{ variables.pythonVersion }}
           poetry_version: ${{ variables.poetryVersion}}
           branchName: ${{ variables.docsBranch }}
+          organisation:  ${{ variables.devops_organisation }}
           pat_username: $(PatUsername)
           pat: $(DevOpsPAT)
-          service_connection: $(AmlServiceConnection)
           clientsecret: $(WikiSecret)
           clientid: $(WikiId)
           tenant: $(TenantName)
-          organisation: $(Organisation)
 {% endraw %}

--- a/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/main.yml
+++ b/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/main.yml
@@ -9,14 +9,9 @@ variables:
 # use complicated ifelse to define feed_view, cannot use if at runtime, only at compile time (and toMain is only available at runtime)
 - name: feed_view
   value: $[replace(replace(or(eq(variables['toMain'], true), eq(variables['isMain'], true)), True, 'prod'), False, 'dvlm')]
-# if we want to register aml environment
-- ${{ if eq(variables['RegisterAmlEnv'], true) }}:
-  # If main, create aml environment in production aml workspace
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-    - group: AmlProdGroup
-  # If not main, create aml environment in development aml workspace
-  - ${{ else }}:
-    - group: AmlDevGroup 
+# If main, create aml environment in production aml workspace
+- ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - group: AmlDevGroup
 # otherwise fallback on development settings
 - ${{ else }}:
   - group: AmlDevGroup 
@@ -118,11 +113,12 @@ stages:
         parameters:
           python_version: ${{ variables.pythonVersion }}
           poetry_version: ${{ variables.poetryVersion}}
+          branchName: ${{ variables.docsBranch }}
           pat_username: $(PatUsername)
           pat: $(DevOpsPAT)
-          keyvault_name: $(SharedKeyvault)
           service_connection: $(AmlServiceConnection)
+          clientsecret: $(WikiSecret)
+          clientid: $(WikiId)
           tenant: $(TenantName)
           organisation: $(Organisation)
-          branchName: ${{ variables.docsBranch }}
 {% endraw %}

--- a/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/main.yml
+++ b/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/main.yml
@@ -11,7 +11,7 @@ variables:
   value: $[replace(replace(or(eq(variables['toMain'], true), eq(variables['isMain'], true)), True, 'prod'), False, 'dvlm')]
 # If main, create aml environment in production aml workspace
 - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-  - group: AmlDevGroup
+  - group: AmlProdGroup
 # otherwise fallback on development settings
 - ${{ else }}:
   - group: AmlDevGroup 

--- a/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/update_wiki.yml
+++ b/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/update_wiki.yml
@@ -13,8 +13,6 @@ parameters:
   type: string
 - name: clientid
   type: string
-- name: service_connection
-  type: string
 - name: tenant
   type: string
 - name: organisation

--- a/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/update_wiki.yml
+++ b/package_repo/{{ cookiecutter.repo_name }}/devops_pipelines/templates/update_wiki.yml
@@ -1,4 +1,5 @@
 {% raw %}
+
 parameters:
 - name: python_version
   type: string
@@ -8,7 +9,9 @@ parameters:
   type: string
 - name: pat
   type: string
-- name: keyvault_name
+- name: clientsecret
+  type: string
+- name: clientid
   type: string
 - name: service_connection
   type: string
@@ -30,13 +33,6 @@ steps:
 - script: poetry install --only docs
   displayName: 'Install docs dependencies with poetry'
 
-- task: AzureKeyVault@2
-  displayName: Obtain Secrets from Key Vault
-  inputs:
-    azureSubscription: '${{ parameters.service_connection }}'
-    KeyVaultName: '${{ parameters.keyvault_name }}'
-    SecretsFilter: 'SP-Wiki-ID,SP-Wiki-SECRET'
-
 - download: current
   artifact: documentation_dir
 
@@ -46,8 +42,8 @@ steps:
       --project $(System.TeamProject) ^
       --name $(Build.Repository.Name) ^
       --branch ${{ parameters.branchName }} ^
-      --clientsecret $(SP-Wiki-SECRET) ^
-      --clientid $(SP-Wiki-ID) ^
+      --clientsecret ${{ parameters.clientsecret }}  ^
+      --clientid ${{ parameters.clientid }}  ^
       --tenant ${{ parameters.tenant }} ^
       --organisation ${{ parameters.organisation }}
   displayName: 'Create/Update Wiki'


### PR DESCRIPTION
Removed keyvault and replaced parameters with (placeholder, did not implement yet) values from devops group.

The keys WikiId and WikiSecret are from now on expected in the AmlProdGroup, this is a breaking change. The WikiGenerator keyvault can now safely be removed though.

